### PR TITLE
Fixing issue with loading the library

### DIFF
--- a/CommonTools/interface/RooACProcessScaling_1D.h
+++ b/CommonTools/interface/RooACProcessScaling_1D.h
@@ -60,6 +60,7 @@ protected:
   
   virtual double evaluate() const ;
   
+  ClassDef(RooACProcessScaling_1D, 0)  
 };
 
 #endif

--- a/CommonTools/interface/RooACProcessScaling_2D.h
+++ b/CommonTools/interface/RooACProcessScaling_2D.h
@@ -66,7 +66,8 @@ protected:
   void readProfiles(RooACProcessScaling_2D const& other);
   
   virtual double evaluate() const ;
-  
+
+  ClassDef(RooACProcessScaling_2D, 0)  
 };
 
 #endif

--- a/CommonTools/interface/RooACProcessScaling_3D.h
+++ b/CommonTools/interface/RooACProcessScaling_3D.h
@@ -68,7 +68,8 @@ protected:
   void readProfiles(RooACProcessScaling_3D const& other);
   
   virtual double evaluate() const ;
-  
+
+  ClassDef(RooACProcessScaling_3D, 0)  
 };
 
 #endif

--- a/CommonTools/interface/RooACSemiAnalyticPdf_1D.h
+++ b/CommonTools/interface/RooACSemiAnalyticPdf_1D.h
@@ -68,7 +68,8 @@ protected:
   void readProfiles(RooACSemiAnalyticPdf_1D const& other);
   
   virtual double evaluate() const ;
-  
+
+  ClassDef(RooACSemiAnalyticPdf_1D, 0)  
 };
 
 #endif

--- a/CommonTools/interface/RooACSemiAnalyticPdf_2D.h
+++ b/CommonTools/interface/RooACSemiAnalyticPdf_2D.h
@@ -71,6 +71,8 @@ protected:
   void readProfiles(RooACSemiAnalyticPdf_2D const& other);
   
   virtual double evaluate() const ;
+
+  ClassDef(RooACSemiAnalyticPdf_2D, 0)
   
 };
 

--- a/CommonTools/interface/RooACSemiAnalyticPdf_3D.h
+++ b/CommonTools/interface/RooACSemiAnalyticPdf_3D.h
@@ -74,6 +74,8 @@ protected:
   void readProfiles(RooACSemiAnalyticPdf_3D const& other);
   
   virtual double evaluate() const ;
+
+  ClassDef(RooACSemiAnalyticPdf_3D, 0)  
   
 };
 

--- a/CommonTools/src/RooACProcessScaling_1D.cc
+++ b/CommonTools/src/RooACProcessScaling_1D.cc
@@ -265,3 +265,4 @@ Double_t RooACProcessScaling_1D::evaluate() const
 
 }
 
+ClassImp(RooACProcessScaling_1D)

--- a/CommonTools/src/RooACProcessScaling_2D.cc
+++ b/CommonTools/src/RooACProcessScaling_2D.cc
@@ -292,3 +292,4 @@ Double_t RooACProcessScaling_2D::evaluate() const
 
 }
 
+ClassImp(RooACProcessScaling_2D)

--- a/CommonTools/src/RooACProcessScaling_3D.cc
+++ b/CommonTools/src/RooACProcessScaling_3D.cc
@@ -304,8 +304,8 @@ Double_t RooACProcessScaling_3D::evaluate() const
 
   for(int i = 0; i<N_bins; i++) {
  
+    std::cout <<"place D: case type= "<<type_ << std::endl;
     switch(type_) {
-      std::cout <<"place D: case type= "<<type_ << std::endl;
     case par1par2par3_TH3:
       ret += P_histo[i]->Interpolate(v1,v2,v3)*integral_basis[i];
       break;

--- a/CommonTools/src/RooACProcessScaling_3D.cc
+++ b/CommonTools/src/RooACProcessScaling_3D.cc
@@ -335,3 +335,4 @@ Double_t RooACProcessScaling_3D::evaluate() const
 
 }
 
+ClassImp(RooACProcessScaling_3D)

--- a/CommonTools/src/RooACSemiAnalyticPdf_1D.cc
+++ b/CommonTools/src/RooACSemiAnalyticPdf_1D.cc
@@ -347,3 +347,5 @@ Double_t RooACSemiAnalyticPdf_1D::analyticalIntegral(Int_t code, const char* ran
 
   return ret;
 }
+
+ClassImp(RooACSemiAnalyticPdf_1D)

--- a/CommonTools/src/RooACSemiAnalyticPdf_2D.cc
+++ b/CommonTools/src/RooACSemiAnalyticPdf_2D.cc
@@ -378,3 +378,5 @@ analyticalIntegral(Int_t code, const char* rangeName) const {
 
   return ret;
 }
+
+ClassImp(RooACSemiAnalyticPdf_2D)

--- a/CommonTools/src/RooACSemiAnalyticPdf_3D.cc
+++ b/CommonTools/src/RooACSemiAnalyticPdf_3D.cc
@@ -443,3 +443,5 @@ analyticalIntegral(Int_t code, const char* rangeName) const {
 
   return ret;
 }
+
+ClassImp(RooACSemiAnalyticPdf_3D)

--- a/CommonTools/src/classes.h
+++ b/CommonTools/src/classes.h
@@ -1,0 +1,7 @@
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACProcessScaling_1D.h"
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACProcessScaling_2D.h"
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACProcessScaling_3D.h"
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACSemiAnalyticPdf_1D.h"
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACSemiAnalyticPdf_2D.h"
+#include "CombinedEWKAnalysis/CommonTools/interface/RooACSemiAnalyticPdf_3D.h"
+

--- a/CommonTools/src/classes_def.xml
+++ b/CommonTools/src/classes_def.xml
@@ -1,4 +1,5 @@
 <lcgdict>
+  <class name="std::vector<std::vector<Float_t>>" />
   <class name="RooACProcessScaling_1D" />
   <class name="RooACProcessScaling_2D" />
   <class name="RooACProcessScaling_3D" />

--- a/CommonTools/src/classes_def.xml
+++ b/CommonTools/src/classes_def.xml
@@ -1,8 +1,8 @@
 <lcgdict>
-  <class name="RooACProcessScaling_1D.h" />
-  <class name="RooACProcessScaling_2D.h" />
-  <class name="RooACProcessScaling_3D.h" />
-  <class name="RooACSemiAnalyticPdf_1D.h" />
-  <class name="RooACSemiAnalyticPdf_2D.h" />
-  <class name="RooACSemiAnalyticPdf_3D.h" />
+  <class name="RooACProcessScaling_1D" />
+  <class name="RooACProcessScaling_2D" />
+  <class name="RooACProcessScaling_3D" />
+  <class name="RooACSemiAnalyticPdf_1D" />
+  <class name="RooACSemiAnalyticPdf_2D" />
+  <class name="RooACSemiAnalyticPdf_3D" />
 </lcgdict>

--- a/CommonTools/src/classes_def.xml
+++ b/CommonTools/src/classes_def.xml
@@ -1,0 +1,8 @@
+<lcgdict>
+  <class name="RooACProcessScaling_1D.h" />
+  <class name="RooACProcessScaling_2D.h" />
+  <class name="RooACProcessScaling_3D.h" />
+  <class name="RooACSemiAnalyticPdf_1D.h" />
+  <class name="RooACSemiAnalyticPdf_2D.h" />
+  <class name="RooACSemiAnalyticPdf_3D.h" />
+</lcgdict>

--- a/CommonTools/test/pyroot_logon.py
+++ b/CommonTools/test/pyroot_logon.py
@@ -108,7 +108,6 @@ gStyle.SetNdivisions(505, "XYZ")
 
 if (gSystem.DynamicPathName("libFWCoreFWLite.so",True)):
     gSystem.Load('libHiggsAnalysisCombinedLimit')
-    gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libMMozerpowhegweight.so")
     gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libHiggsAnalysisCombinedLimit.so")
     gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libCombinedEWKAnalysisCommonTools.so")
     gROOT.GetInterpreter().AddIncludePath(cmssw_base + '/src')
@@ -120,26 +119,8 @@ if (gSystem.DynamicPathName("libFWCoreFWLite.so",True)):
         RooFitInclude()
         print 'returning to working directory', workingdir
         os.chdir(workingdir)
-    gROOT.ProcessLine('.L EffTableReader.cc+')
-    gROOT.ProcessLine('.L EffTableLoader.cc+')
-    gROOT.ProcessLine('.L CPWeighter.cc+')
-    
-    if not TClass.GetClass('RooPowerLaw'):
-        # print 'importing RooFit PDF classes'
-        gROOT.ProcessLine('.L RooPowerLaw.cc+')
-    if not TClass.GetClass('RooPowerExpPdf'):
-        gROOT.ProcessLine('.L RooPowerExpPdf.cxx+')
-    if not TClass.GetClass('RooErfExpPdf'):
-        gROOT.ProcessLine('.L RooErfExpPdf.cxx+')
-    if not TClass.GetClass('RooErfPdf'):
-        gROOT.ProcessLine('.L RooErfPdf.cxx+')
-    if not TClass.GetClass('RooTH1DPdf'):
-        gROOT.ProcessLine('.L RooTH1DPdf.cxx+')
-    if not TClass.GetClass('RooChebyshevPdf'):
-        gROOT.ProcessLine('.L RooChebyshevPDF.cc+')
-    if not TClass.GetClass('alphaFunction'):
-        gROOT.ProcessLine('.L alphaFunction.cxx+')        
-    
+
+
 print 'end of pyroot_logon'
 
 if __name__ == '__main__':

--- a/CommonTools/test/pyroot_logon.py
+++ b/CommonTools/test/pyroot_logon.py
@@ -109,7 +109,8 @@ gStyle.SetNdivisions(505, "XYZ")
 if (gSystem.DynamicPathName("libFWCoreFWLite.so",True)):
     gSystem.Load('libHiggsAnalysisCombinedLimit')
     gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libMMozerpowhegweight.so")
-    res = gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libHiggsAnalysisCombinedLimit.so")
+    gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libHiggsAnalysisCombinedLimit.so")
+    gSystem.Load("$CMSSW_BASE/lib/$SCRAM_ARCH/libCombinedEWKAnalysisCommonTools.so")
     gROOT.GetInterpreter().AddIncludePath(cmssw_base + '/src')
     gSystem.AddIncludePath('-I"' + cmssw_base + '/src"')
     if not RooFitInclude():


### PR DESCRIPTION
It turns out that the classdefs were crucial for the damn pyroot to understand there are classes :)

I have also cleaned up the pyroot_logon file  from Matthias' module and all the macros it loaded, because they are likely all things from that module and are currently not used anymore (no match when grepping them)